### PR TITLE
fix: stabilize tray popup release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.2.5 - Tray Popup Stability Hotfix
+
+Release type: patch
+
+This release fixes macOS tray popup behavior seen in bundled builds and improves auto-reconnect cleanup after sleep/wake.
+
+### Fixed
+
+- Disabled the native macOS/Tauri tray menu fallback so FrieRay consistently opens the custom tray popup.
+- Tray popup is now created lazily on click instead of being pre-created at startup, reducing center-screen/default-position flashes.
+- Popup positioning now anchors to the tray icon rectangle and clamps to the active monitor work area.
+- Connected tray popup layout now has enough height for Disconnect, Find replacement, and Open app actions without clipping.
+- Auto-reconnect now cleans stale Xray/TUN/system-proxy state before rescanning servers, which helps recovery after Mac sleep/wake.
+- Disconnect cleanup is best-effort, so a stale Xray stop error no longer blocks proxy/TUN reset and fresh reconnect attempts.
+
+### Verification
+
+- `npm audit --audit-level=moderate`
+- `npm run build`
+- `cargo test`
+- `cargo check`
+- `npm run tauri build`
+
 ## v0.2.4 - Tray Reliability and Release UI Cleanup
 
 Release type: patch

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FrieRay
 
 [![CI](https://github.com/MrGodgames/FrieRay/actions/workflows/ci.yml/badge.svg)](https://github.com/MrGodgames/FrieRay/actions/workflows/ci.yml)
-![Version](https://img.shields.io/badge/version-0.2.4-blue)
+![Version](https://img.shields.io/badge/version-0.2.5-blue)
 ![Platform](https://img.shields.io/badge/platform-macOS-lightgrey)
 ![Tauri](https://img.shields.io/badge/Tauri-2.x-24C8DB)
 ![React](https://img.shields.io/badge/React-19-61DAFB)
@@ -46,14 +46,14 @@ FrieRay is being prepared for a wider open-source roadmap: Linux and Windows por
 
 ## Release
 
-Latest prepared version: `v0.2.4`
+Latest prepared version: `v0.2.5`
 
 Prebuilt macOS builds are published through [GitHub Releases](https://github.com/MrGodgames/FrieRay/releases).
 
 Expected macOS artifact names:
 
 ```text
-FrieRay_0.2.4_aarch64.dmg
+FrieRay_0.2.5_aarch64.dmg
 FrieRay.app
 ```
 
@@ -225,7 +225,7 @@ FrieRay — десктопный V2Ray/Xray-клиент для macOS на Tauri
 
 ### Безопасность
 
-В версии `0.2.4` улучшен tray workflow и сохранены базовые настройки безопасности: HTTPS для удалённых подписок, приватные права на локальные конфиги, CSP для webview, удалены shell-permissions из Tauri frontend, а URL подписок больше не логируются целиком.
+В версии `0.2.5` улучшена стабильность tray popup, позиционирование и автопереподключение после sleep/wake; в `0.2.4` был улучшен tray workflow и сохранены базовые настройки безопасности: HTTPS для удалённых подписок, приватные права на локальные конфиги, CSP для webview, удалены shell-permissions из Tauri frontend, а URL подписок больше не логируются целиком.
 
 Следующие задачи по безопасности: macOS Keychain для секретов, checksum для `tun2socks`, улучшенный uninstall для TUN helper и поддержка dependency audit в CI в зелёном состоянии.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -41,7 +41,7 @@ src-tauri/target/release/bundle/dmg/
 
 ## GitHub release
 
-1. Create a tag such as `v0.2.4`.
+1. Create a tag such as `v0.2.5`.
 2. Publish a GitHub release with:
    - summary of changes
    - security notes, if any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frieray",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frieray",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frieray",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A macOS desktop V2Ray/Xray client built with Tauri, React, and Rust.",
   "type": "module",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "frieray"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frieray"
-version = "0.2.4"
+version = "0.2.5"
 description = "A macOS desktop V2Ray/Xray client built with Tauri, React, and Rust."
 authors = ["MrGodgames"]
 license = "MIT"

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -40,6 +40,25 @@ async fn connect_ranked_server_with_app(
         None
     };
     let excluded_ids = current_id.into_iter().collect::<Vec<_>>();
+
+    if state.xray.is_running().await {
+        let _ = app.emit(
+            crate::commands::servers::AUTO_SELECT_PROGRESS_EVENT,
+            crate::commands::servers::AutoSelectProgress {
+                stage: "disconnect".to_string(),
+                message: "Отключаю текущее соединение перед проверкой серверов...".into(),
+            },
+        );
+        state
+            .logs
+            .add(
+                "info",
+                "Автовыбор сервера: очищаю текущее TUN/proxy соединение перед ресканом...",
+            )
+            .await;
+        let _ = disconnect_with_state(&state).await;
+    }
+
     let candidates = crate::commands::servers::rank_servers_for_auto_select(
         app,
         &state,
@@ -47,17 +66,6 @@ async fn connect_ranked_server_with_app(
         &excluded_ids,
     )
     .await?;
-
-    if state.xray.is_running().await {
-        let _ = app.emit(
-            crate::commands::servers::AUTO_SELECT_PROGRESS_EVENT,
-            crate::commands::servers::AutoSelectProgress {
-                stage: "disconnect".to_string(),
-                message: "Отключаю текущее соединение перед сменой сервера...".into(),
-            },
-        );
-        let _ = disconnect_with_state(&state).await;
-    }
 
     let mut last_error = None;
 
@@ -108,7 +116,10 @@ async fn connect_ranked_server_with_app(
                     .logs
                     .add(
                         "warn",
-                        &format!("{} не прошёл подключение, пробую следующий сервер", server.name),
+                        &format!(
+                            "{} не прошёл подключение, пробую следующий сервер",
+                            server.name
+                        ),
                     )
                     .await;
                 let _ = app.emit(
@@ -329,9 +340,14 @@ pub async fn disconnect_with_state(state: &AppState) -> Result<String, String> {
         state.logs.add("warn", &format!("TUN stop: {}", e)).await;
     }
 
-    // Stop xray
-    state.xray.stop().await?;
-    state.logs.add("info", "Xray-core остановлен").await;
+    // Stop xray. Disconnect must be best-effort: after sleep/wake the process or
+    // local sockets can be stale, but proxy/TUN/current-server state still needs
+    // cleanup so a fresh scan/reconnect is not blocked.
+    if let Err(e) = state.xray.stop().await {
+        state.logs.add("warn", &format!("Xray stop: {}", e)).await;
+    } else {
+        state.logs.add("info", "Xray-core остановлен").await;
+    }
 
     // Always unset system proxy on disconnect, just to be safe
     // in case it was set by a fallback or previous session

--- a/src-tauri/src/commands/servers.rs
+++ b/src-tauri/src/commands/servers.rs
@@ -308,10 +308,7 @@ pub async fn rank_servers_for_auto_select(
         emit_auto_select_progress(
             app,
             "selected",
-            &format!(
-                "Выбран сервер: {} ({:.1} Mb/s)",
-                server.name, speed
-            ),
+            &format!("Выбран сервер: {} ({:.1} Mb/s)", server.name, speed),
         );
     }
 

--- a/src-tauri/src/core/tray.rs
+++ b/src-tauri/src/core/tray.rs
@@ -1,30 +1,18 @@
-use crate::commands::connection::{
-    connect_best_server_rescan_with_app, connect_with_state, disconnect_with_state,
-    reconnect_best_server_rescan_with_app,
-};
+use crate::commands::connection::{connect_with_state, reconnect_best_server_rescan_with_app};
 use crate::commands::servers::ping_server;
 use crate::models::server::Server;
-use crate::utils::storage;
 use crate::AppState;
 use tauri::image::Image;
-use tauri::menu::{CheckMenuItem, Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{
-    ActivationPolicy, App, AppHandle, Manager, PhysicalPosition, WebviewUrl, WebviewWindow,
+    ActivationPolicy, App, AppHandle, Manager, PhysicalPosition, Rect, WebviewUrl, WebviewWindow,
     WebviewWindowBuilder,
 };
 
 const TRAY_ID: &str = "main-tray";
 const TRAY_POPUP_LABEL: &str = "tray-popup";
-const MENU_STATUS: &str = "tray-status";
-const MENU_CURRENT: &str = "tray-current";
-const MENU_CONNECT: &str = "tray-connect";
-const MENU_DISCONNECT: &str = "tray-disconnect";
-const MENU_TOGGLE_WINDOW: &str = "tray-toggle-window";
-const MENU_QUIT: &str = "tray-quit";
-const MENU_SERVER_PREFIX: &str = "tray-server:";
 const TRAY_POPUP_WIDTH: f64 = 360.0;
-const TRAY_POPUP_HEIGHT: f64 = 280.0;
+const TRAY_POPUP_HEIGHT: f64 = 320.0;
 const TRAY_POPUP_MARGIN: f64 = 10.0;
 const HEALTH_CHECK_INTERVAL_SECS: u64 = 15;
 const HEALTH_CHECK_FAILURES_BEFORE_FAILOVER: u8 = 2;
@@ -35,23 +23,16 @@ struct TraySnapshot {
     connected: bool,
     current_server: Option<Server>,
     active_server: Option<Server>,
-    servers: Vec<Server>,
-    window_hidden: bool,
 }
 
 pub fn setup(app: &mut App) -> tauri::Result<()> {
     let app_handle = app.handle().clone();
     let snapshot = collect_tray_snapshot(&app_handle);
-    let menu = build_tray_menu(&app_handle, &snapshot)?;
 
     let mut tray_builder = TrayIconBuilder::with_id(TRAY_ID)
-        .menu(&menu)
         .tooltip(build_tray_tooltip(&snapshot))
         .icon_as_template(false)
         .show_menu_on_left_click(false)
-        .on_menu_event(|app, event| {
-            handle_menu_event(app, event.id().as_ref().to_string());
-        })
         .on_tray_icon_event(|tray, event| {
             handle_tray_icon_event(tray.app_handle(), event);
         });
@@ -61,7 +42,6 @@ pub fn setup(app: &mut App) -> tauri::Result<()> {
     }
 
     tray_builder.build(app)?;
-    let _ = ensure_tray_popup_window(&app_handle);
     start_connection_health_monitor(&app_handle);
     Ok(())
 }
@@ -98,10 +78,7 @@ fn start_connection_health_monitor(app: &AppHandle) {
                             "warn",
                             &format!(
                                 "Tray health check: {} не отвечает ({}/{}): {}",
-                                server.name,
-                                failures,
-                                HEALTH_CHECK_FAILURES_BEFORE_FAILOVER,
-                                error
+                                server.name, failures, HEALTH_CHECK_FAILURES_BEFORE_FAILOVER, error
                             ),
                         )
                         .await;
@@ -115,7 +92,8 @@ fn start_connection_health_monitor(app: &AppHandle) {
                             )
                             .await;
 
-                        if let Err(error) = reconnect_best_server_rescan_with_app(&app_handle).await {
+                        if let Err(error) = reconnect_best_server_rescan_with_app(&app_handle).await
+                        {
                             let state = app_handle.state::<AppState>();
                             state
                                 .logs
@@ -146,8 +124,11 @@ fn refresh_tray_with_snapshot(app: &AppHandle, snapshot: &TraySnapshot) -> Resul
         return Ok(());
     };
 
-    let menu = build_tray_menu(app, snapshot).map_err(|e| e.to_string())?;
-    tray.set_menu(Some(menu)).map_err(|e| e.to_string())?;
+    // Keep the native tray menu disabled. FrieRay uses a custom webview popup so
+    // the menu-bar interaction feels like the app UI instead of falling back to
+    // the default macOS context menu on some machines/right-clicks.
+    tray.set_menu(None::<tauri::menu::Menu<tauri::Wry>>)
+        .map_err(|e| e.to_string())?;
     tray.set_tooltip(Some(build_tray_tooltip(snapshot)))
         .map_err(|e| e.to_string())?;
     tray.set_title(None::<String>).map_err(|e| e.to_string())?;
@@ -243,81 +224,18 @@ fn tray_icon_image(connected: bool) -> Option<Image<'static>> {
     Some(Image::new_owned(rgba, base.width(), base.height()))
 }
 
-fn handle_menu_event(app: &AppHandle, id: String) {
-    match id.as_str() {
-        MENU_TOGGLE_WINDOW => {
-            let snapshot = collect_tray_snapshot(app);
-            let result = if snapshot.window_hidden {
-                show_main_window(app)
-            } else {
-                hide_main_window(app)
-            };
-            if let Err(error) = result {
-                log::warn!("Tray window toggle: {}", error);
-            }
-        }
-        MENU_QUIT => {
-            app.exit(0);
-        }
-        MENU_CONNECT => {
-            let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                if let Err(error) = connect_best_server_rescan_with_app(&app_handle).await {
-                    let state = app_handle.state::<AppState>();
-                    state
-                        .logs
-                        .add("error", &format!("Tray connect: {}", error))
-                        .await;
-                }
-                let _ = refresh_tray_async(&app_handle).await;
-            });
-        }
-        MENU_DISCONNECT => {
-            let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                let state = app_handle.state::<AppState>();
-                if let Err(error) = disconnect_with_state(&state).await {
-                    state
-                        .logs
-                        .add("error", &format!("Tray disconnect: {}", error))
-                        .await;
-                }
-                let _ = refresh_tray_async(&app_handle).await;
-            });
-        }
-        _ if id.starts_with(MENU_SERVER_PREFIX) => {
-            let server_id = id.trim_start_matches(MENU_SERVER_PREFIX).to_string();
-            let app_handle = app.clone();
-            tauri::async_runtime::spawn(async move {
-                if let Err(error) = select_server_from_tray(&app_handle, &server_id).await {
-                    let state = app_handle.state::<AppState>();
-                    state
-                        .logs
-                        .add("error", &format!("Tray server switch: {}", error))
-                        .await;
-                }
-                let _ = refresh_tray_async(&app_handle).await;
-            });
-        }
-        _ => {}
-    }
-}
-
 fn handle_tray_icon_event(app: &AppHandle, event: TrayIconEvent) {
     if let TrayIconEvent::Click {
         button,
         button_state: MouseButtonState::Up,
         position,
+        rect,
         ..
     } = event
     {
         match button {
-            MouseButton::Left => {
-                let _ = toggle_tray_popup(app, position);
-                let _ = refresh_tray(app);
-            }
-            MouseButton::Right => {
-                hide_tray_popup(app);
+            MouseButton::Left | MouseButton::Right => {
+                let _ = toggle_tray_popup(app, position, rect);
                 let _ = refresh_tray(app);
             }
             _ => {}
@@ -350,7 +268,11 @@ fn ensure_tray_popup_window(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-fn toggle_tray_popup(app: &AppHandle, position: PhysicalPosition<f64>) -> Result<(), String> {
+fn toggle_tray_popup(
+    app: &AppHandle,
+    position: PhysicalPosition<f64>,
+    rect: Rect,
+) -> Result<(), String> {
     ensure_tray_popup_window(app)?;
     let popup = app
         .get_webview_window(TRAY_POPUP_LABEL)
@@ -361,7 +283,7 @@ fn toggle_tray_popup(app: &AppHandle, position: PhysicalPosition<f64>) -> Result
         return Ok(());
     }
 
-    position_tray_popup(app, &popup, position)?;
+    position_tray_popup(app, &popup, position, rect)?;
     popup.show().map_err(|e| e.to_string())?;
     popup.set_focus().map_err(|e| e.to_string())?;
     Ok(())
@@ -377,24 +299,47 @@ fn position_tray_popup(
     app: &AppHandle,
     popup: &WebviewWindow,
     position: PhysicalPosition<f64>,
+    rect: Rect,
 ) -> Result<(), String> {
-    let mut x = position.x - (TRAY_POPUP_WIDTH / 2.0);
-    let mut y = position.y + TRAY_POPUP_MARGIN;
+    let anchor = tray_anchor_point(position, rect);
+    let mut x = anchor.x - (TRAY_POPUP_WIDTH / 2.0);
+    let mut y = anchor.y + TRAY_POPUP_MARGIN;
 
-    if let Some(bounds) = monitor_bounds_for_point(app, position) {
+    if let Some(bounds) =
+        monitor_bounds_for_point(app, anchor).or_else(|| primary_monitor_bounds(app))
+    {
         let min_x = bounds.0;
         let max_x = bounds.0 + bounds.2 - TRAY_POPUP_WIDTH;
+        let min_y = bounds.1 + TRAY_POPUP_MARGIN;
         let max_y = bounds.1 + bounds.3 - TRAY_POPUP_HEIGHT - TRAY_POPUP_MARGIN;
+        let screen_mid_y = bounds.1 + bounds.3 / 2.0;
+        y = if anchor.y > screen_mid_y {
+            anchor.y - TRAY_POPUP_HEIGHT - TRAY_POPUP_MARGIN
+        } else {
+            anchor.y + TRAY_POPUP_MARGIN
+        };
         x = x.clamp(min_x, max_x.max(min_x));
-        y = y.clamp(
-            bounds.1 + TRAY_POPUP_MARGIN,
-            max_y.max(bounds.1 + TRAY_POPUP_MARGIN),
-        );
+        y = y.clamp(min_y, max_y.max(min_y));
     }
 
     popup
         .set_position(PhysicalPosition::new(x.round() as i32, y.round() as i32))
         .map_err(|e| e.to_string())
+}
+
+fn tray_anchor_point(position: PhysicalPosition<f64>, rect: Rect) -> PhysicalPosition<f64> {
+    let (rect_width, rect_height) = match rect.size {
+        tauri::Size::Physical(size) => (size.width as f64, size.height as f64),
+        tauri::Size::Logical(size) => (size.width, size.height),
+    };
+    let (rect_x, rect_y) = match rect.position {
+        tauri::Position::Physical(position) => (position.x as f64, position.y as f64),
+        tauri::Position::Logical(position) => (position.x, position.y),
+    };
+    if rect_width > 0.0 && rect_height > 0.0 {
+        return PhysicalPosition::new(rect_x + rect_width / 2.0, rect_y + rect_height);
+    }
+    position
 }
 
 fn monitor_bounds_for_point(
@@ -418,37 +363,18 @@ fn monitor_bounds_for_point(
     None
 }
 
-async fn select_server_from_tray(app: &AppHandle, server_id: &str) -> Result<(), String> {
-    let state = app.state::<AppState>();
-    let server = {
-        let servers = state.servers.lock().await;
-        servers
-            .iter()
-            .find(|server| server.id == server_id)
-            .cloned()
-            .ok_or_else(|| "Сервер не найден".to_string())?
-    };
-
-    {
-        let mut active = state.active_server.lock().await;
-        *active = Some(server.clone());
-    }
-    storage::save_active_server_id(&server.id)?;
-
-    if state.xray.is_running().await {
-        disconnect_with_state(&state).await?;
-        connect_with_state(server.clone(), &state).await?;
-    } else {
-        state
-            .logs
-            .add(
-                "info",
-                &format!("Активный сервер изменён на {}", server.name),
-            )
-            .await;
-    }
-
-    Ok(())
+fn primary_monitor_bounds(app: &AppHandle) -> Option<(f64, f64, f64, f64)> {
+    let probe = app
+        .get_webview_window(TRAY_POPUP_LABEL)
+        .or_else(|| app.get_webview_window("main"))?;
+    let monitor = probe.primary_monitor().ok().flatten()?;
+    let work_area = monitor.work_area();
+    Some((
+        work_area.position.x as f64,
+        work_area.position.y as f64,
+        work_area.size.width as f64,
+        work_area.size.height as f64,
+    ))
 }
 
 fn collect_tray_snapshot(app: &AppHandle) -> TraySnapshot {
@@ -460,107 +386,12 @@ async fn collect_tray_snapshot_async(app: &AppHandle) -> TraySnapshot {
     let connected = state.xray.is_running().await;
     let current_server = state.current_server.lock().await.clone();
     let active_server = state.active_server.lock().await.clone();
-    let servers = state.servers.lock().await.clone();
-    let window_hidden = app
-        .get_webview_window("main")
-        .and_then(|window| {
-            let is_visible = window.is_visible().ok()?;
-            let is_minimized = window.is_minimized().ok().unwrap_or(false);
-            Some(!is_visible || is_minimized)
-        })
-        .unwrap_or(false);
 
     TraySnapshot {
         connected,
         current_server,
         active_server,
-        servers,
-        window_hidden,
     }
-}
-
-fn build_tray_menu(app: &AppHandle, snapshot: &TraySnapshot) -> tauri::Result<Menu<tauri::Wry>> {
-    let status_text = if snapshot.connected {
-        "Статус: подключено"
-    } else {
-        "Статус: не подключено"
-    };
-    let current_text = match snapshot
-        .current_server
-        .as_ref()
-        .or(snapshot.active_server.as_ref())
-    {
-        Some(server) => format!("Сервер: {}", server.name),
-        None => "Сервер: не выбран".to_string(),
-    };
-
-    let mut server_list = snapshot.servers.clone();
-    let active_server_id = snapshot
-        .active_server
-        .as_ref()
-        .map(|server| server.id.as_str());
-    server_list.sort_by(|left, right| {
-        let left_active = Some(left.id.as_str()) == active_server_id;
-        let right_active = Some(right.id.as_str()) == active_server_id;
-        right_active
-            .cmp(&left_active)
-            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
-    });
-
-    let mut server_submenu_builder = SubmenuBuilder::new(app, "Серверы");
-    if server_list.is_empty() {
-        let empty_item = MenuItemBuilder::with_id("tray-no-servers", "Нет серверов")
-            .enabled(false)
-            .build(app)?;
-        server_submenu_builder = server_submenu_builder.item(&empty_item);
-    } else {
-        for server in &server_list {
-            let server_item = CheckMenuItem::with_id(
-                app,
-                format!("{MENU_SERVER_PREFIX}{}", server.id),
-                &server.name,
-                true,
-                Some(server.id.as_str()) == active_server_id,
-                None::<&str>,
-            )?;
-            server_submenu_builder = server_submenu_builder.item(&server_item);
-        }
-    }
-    let servers_submenu = server_submenu_builder.build()?;
-
-    let status_item = MenuItemBuilder::with_id(MENU_STATUS, status_text)
-        .enabled(false)
-        .build(app)?;
-    let current_item = MenuItemBuilder::with_id(MENU_CURRENT, current_text)
-        .enabled(false)
-        .build(app)?;
-    let connect_item = MenuItemBuilder::with_id(MENU_CONNECT, "Пересканировать и подключить")
-        .enabled(!snapshot.connected && !server_list.is_empty())
-        .build(app)?;
-    let disconnect_item = MenuItemBuilder::with_id(MENU_DISCONNECT, "Отключить")
-        .enabled(snapshot.connected)
-        .build(app)?;
-    let window_toggle_text = if snapshot.window_hidden {
-        "Показать окно"
-    } else {
-        "Скрыть окно"
-    };
-    let window_toggle_item =
-        MenuItemBuilder::with_id(MENU_TOGGLE_WINDOW, window_toggle_text).build(app)?;
-    let quit_item = MenuItemBuilder::with_id(MENU_QUIT, "Выйти из FrieRay").build(app)?;
-
-    MenuBuilder::new(app)
-        .item(&status_item)
-        .item(&current_item)
-        .separator()
-        .item(&connect_item)
-        .item(&disconnect_item)
-        .separator()
-        .item(&window_toggle_item)
-        .item(&servers_submenu)
-        .separator()
-        .item(&quit_item)
-        .build()
 }
 
 fn build_tray_tooltip(snapshot: &TraySnapshot) -> String {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "FrieRay",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "com.dreamsoftware.frieray",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -147,7 +147,7 @@ export default function Sidebar() {
                     )}
                     <span>{theme === 'dark' ? t('themeDay') : t('themeNight')}</span>
                 </button>
-                <div className="sidebar-version">v0.2.4</div>
+                <div className="sidebar-version">v0.2.5</div>
             </div>
         </aside>
     );

--- a/src/pages/TrayPopup.css
+++ b/src/pages/TrayPopup.css
@@ -12,11 +12,11 @@ html, body {
     height: calc(100vh - 14px);
     margin: 7px;
     overflow: hidden;
-    padding: 12px;
-    gap: 8px;
+    padding: 10px;
+    gap: 7px;
     color: var(--text-primary);
     box-sizing: border-box;
-    border-radius: 16px;
+    border-radius: 15px;
     border: 1px solid rgba(255, 255, 255, 0.14);
     background:
         radial-gradient(circle at 50% -18%, rgba(139, 106, 255, 0.28), transparent 36%),
@@ -39,7 +39,7 @@ html, body {
 
 .tray-popup-caret {
     position: absolute;
-    top: -4px;
+    top: -3px;
     left: 50%;
     width: 12px;
     height: 12px;
@@ -73,13 +73,13 @@ html, body {
 .tray-popup-title-row {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 7px;
     min-width: 0;
 }
 
 .tray-popup-dot {
-    width: 9px;
-    height: 9px;
+    width: 8px;
+    height: 8px;
     border-radius: 999px;
     background: rgba(170, 160, 195, 0.7);
     box-shadow: 0 0 0 4px rgba(170, 160, 195, 0.08);
@@ -94,16 +94,16 @@ html, body {
     flex: 1;
     min-width: 0;
     font-family: var(--font-heading);
-    font-size: 1.05rem;
+    font-size: 1rem;
     font-weight: 700;
     letter-spacing: 0.04em;
     line-height: 1;
 }
 
 .tray-popup-status {
-    padding: 4px 9px;
+    padding: 4px 8px;
     border-radius: 999px;
-    font-size: 0.62rem;
+    font-size: 0.6rem;
     font-weight: 800;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -121,9 +121,9 @@ html, body {
 .tray-popup-server-card {
     display: flex;
     align-items: center;
-    gap: 10px;
-    margin-top: 9px;
-    padding: 9px 10px;
+    gap: 9px;
+    margin-top: 8px;
+    padding: 8px 9px;
     border-radius: 12px;
     border: 1px solid rgba(139, 106, 255, 0.18);
     background: rgba(255, 255, 255, 0.045);
@@ -132,9 +132,9 @@ html, body {
 .tray-popup-server-icon {
     display: grid;
     place-items: center;
-    width: 24px;
-    height: 24px;
-    flex: 0 0 24px;
+    width: 23px;
+    height: 23px;
+    flex: 0 0 23px;
     border-radius: 8px;
     color: #d9c8ff;
     background: rgba(139, 106, 255, 0.16);
@@ -150,7 +150,7 @@ html, body {
 .tray-popup-server-label {
     overflow: hidden;
     color: var(--text-muted);
-    font-size: 0.64rem;
+    font-size: 0.6rem;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -161,7 +161,7 @@ html, body {
 .tray-popup-server-name {
     overflow: hidden;
     color: var(--text-primary);
-    font-size: 0.84rem;
+    font-size: 0.8rem;
     font-weight: 700;
     line-height: 1.25;
     text-overflow: ellipsis;
@@ -249,12 +249,12 @@ html, body {
     align-items: center;
     justify-content: space-between;
     gap: 8px;
-    padding: 7px 10px;
+    padding: 7px 9px;
     border-radius: 12px;
     color: var(--text-muted);
     border: 1px solid rgba(139, 106, 255, 0.14);
     background: rgba(255, 255, 255, 0.03);
-    font-size: 0.72rem;
+    font-size: 0.68rem;
 }
 
 .tray-popup-health-main {
@@ -271,6 +271,12 @@ html, body {
     flex: 0 0 7px;
     border-radius: 999px;
     background: var(--text-muted);
+}
+
+.tray-popup-health-main span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .tray-popup-health-card.ping-good .tray-popup-health-dot,
@@ -299,8 +305,8 @@ html, body {
 .tray-popup-actions {
     display: flex;
     flex-direction: column;
-    gap: 3px;
-    padding: 4px;
+    gap: 2px;
+    padding: 3px;
     border-radius: 14px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.035);
@@ -311,11 +317,11 @@ html, body {
     align-items: center;
     gap: 10px;
     width: 100%;
-    min-height: 32px;
-    padding: 8px 10px;
+    min-height: 31px;
+    padding: 6px 9px;
     color: var(--text-secondary);
     font: inherit;
-    font-size: 0.86rem;
+    font-size: 0.8rem;
     font-weight: 700;
     text-align: left;
     border: 0;
@@ -342,9 +348,9 @@ html, body {
 .tray-menu-action-icon {
     display: grid;
     place-items: center;
-    width: 22px;
-    height: 22px;
-    flex: 0 0 22px;
+    width: 21px;
+    height: 21px;
+    flex: 0 0 21px;
     border-radius: 7px;
     color: #d9c8ff;
     background: rgba(139, 106, 255, 0.14);
@@ -372,10 +378,10 @@ html, body {
 .tray-popup-meta {
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: 5px;
     flex: 0 0 auto;
     color: var(--text-secondary);
-    font-size: 0.72rem;
+    font-size: 0.66rem;
     font-weight: 800;
     font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Summary
- fixes bundled macOS tray popup positioning and native-menu fallback
- prevents connected tray popup actions from clipping
- cleans stale Xray/TUN/proxy state before sleep/wake failover rescans
- bumps release metadata to v0.2.5 and updates README/CHANGELOG/release docs

## Verification
- npm audit --audit-level=moderate
- npm run build
- cd src-tauri && cargo test && cargo check
- npm run tauri build
- git diff --check